### PR TITLE
Fix bug with cancelRegistration and CancelRegistrationMessage serialization

### DIFF
--- a/client/src/main/scala/com/lnvortex/client/VortexClient.scala
+++ b/client/src/main/scala/com/lnvortex/client/VortexClient.scala
@@ -108,6 +108,7 @@ case class VortexClient[+T <: VortexWalletApi](vortexWallet: T)(implicit
   }
 
   def cancelRegistration(): Future[Unit] = {
+    logger.info("Canceling registration")
     getNonceOpt(roundDetails) match {
       case Some(nonce) =>
         handlerP.future.map { handler =>

--- a/core-test/src/main/scala/com/lnvortex/core/gen/Generators.scala
+++ b/core-test/src/main/scala/com/lnvortex/core/gen/Generators.scala
@@ -119,4 +119,11 @@ object Generators {
       nonceMsg <- nonceMsg
     } yield RestartRoundMessage(mixDetails, nonceMsg)
   }
+
+  def cancelRegistrationMessage: Gen[CancelRegistrationMessage] = {
+    for {
+      roundId <- CryptoGenerators.doubleSha256Digest
+      nonce <- CryptoGenerators.schnorrNonce
+    } yield CancelRegistrationMessage(nonce, roundId)
+  }
 }

--- a/core-test/src/test/scala/com/lnvortex/core/VortexMessageSerializationTest.scala
+++ b/core-test/src/test/scala/com/lnvortex/core/VortexMessageSerializationTest.scala
@@ -111,4 +111,11 @@ class VortexMessageSerializationTest extends BitcoinSUnitTest {
       assert(VortexMessage(msg.bytes) == msg)
     }
   }
+
+  "CancelRegistrationMessage" must "have serialization symmetry" in {
+    forAll(Generators.cancelRegistrationMessage) { msg =>
+      assert(CancelRegistrationMessage(msg.bytes) == msg)
+      assert(VortexMessage(msg.bytes) == msg)
+    }
+  }
 }

--- a/core/src/main/scala/com/lnvortex/core/VortexMessage.scala
+++ b/core/src/main/scala/com/lnvortex/core/VortexMessage.scala
@@ -479,7 +479,7 @@ case class CancelRegistrationMessage(
     nonce: SchnorrNonce,
     roundId: DoubleSha256Digest)
     extends ClientVortexMessage {
-  override val tpe: BigSizeUInt = RestartRoundMessage.tpe
+  override val tpe: BigSizeUInt = CancelRegistrationMessage.tpe
 
   override lazy val value: ByteVector = nonce.bytes ++ roundId.bytes
 }
@@ -493,7 +493,7 @@ object CancelRegistrationMessage
   override def fromTLVValue(value: ByteVector): CancelRegistrationMessage = {
     val iter = ValueIterator(value)
 
-    val nonce = iter.take(SchnorrNonce)
+    val nonce = iter.take(SchnorrNonce, 32)
     val roundId = iter.take(DoubleSha256Digest)
 
     CancelRegistrationMessage(nonce, roundId)

--- a/server/src/main/scala/com/lnvortex/server/coordinator/VortexCoordinator.scala
+++ b/server/src/main/scala/com/lnvortex/server/coordinator/VortexCoordinator.scala
@@ -349,10 +349,12 @@ case class VortexCoordinator(bitcoind: BitcoindRpcClient)(implicit
           throw new IllegalArgumentException(
             s"No alice found with nonce $nonce")
       }
-      updated = aliceDb.unregister()
-      _ <- aliceDAO.updateAction(updated)
-      _ <- inputsDAO.deleteByPeerIdAction(updated.peerId, updated.roundId)
-      _ = signedPMap.remove(updated.peerId)
+      _ = logger.info(s"Alice ${aliceDb.peerId} canceling registration")
+
+      _ <- aliceDAO.deleteAction(aliceDb)
+      _ <- inputsDAO.deleteByPeerIdAction(aliceDb.peerId, aliceDb.roundId)
+      _ = signedPMap.remove(aliceDb.peerId)
+      _ = connectionHandlerMap.remove(aliceDb.peerId)
     } yield ()
 
     safeDatabase.run(action)


### PR DESCRIPTION
`CancelRegistrationMessage` was using the wrong type number.

Fixed the coordinator `cancelRegistration` to fully remove the alice