### PR TITLE
Immuatable coordinator refactor

### DIFF
--- a/client-server-test/src/test/scala/com/lnvortex/server/RemixNetworkingTest.scala
+++ b/client-server-test/src/test/scala/com/lnvortex/server/RemixNetworkingTest.scala
@@ -1,0 +1,112 @@
+package com.lnvortex.server
+
+import akka.http.scaladsl.model.ws.Message
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl._
+import com.lnvortex.core.ClientStatus._
+import com.lnvortex.testkit._
+import org.bitcoins.core.script.ScriptType
+import org.bitcoins.core.script.ScriptType._
+import org.bitcoins.core.util.EnvUtil
+import org.bitcoins.testkit.EmbeddedPg
+import org.bitcoins.testkit.async.TestAsyncUtil
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+class RemixNetworkingTest
+    extends DualClientFixture
+    with ClientServerTestUtils
+    with EmbeddedPg {
+  override val isNetworkingTest = false
+  override val outputScriptType: ScriptType = WITNESS_V1_TAPROOT
+  override val changeScriptType: ScriptType = WITNESS_V1_TAPROOT
+  override val inputScriptType: ScriptType = WITNESS_V1_TAPROOT
+
+  val interval: FiniteDuration =
+    if (torEnabled) 500.milliseconds else 100.milliseconds
+
+  val maxTries: Int = if (EnvUtil.isCI) 500 else 50
+
+  override def getDummyQueue: SourceQueueWithComplete[Message] = Source
+    .queue[Message](bufferSize = 10,
+                    OverflowStrategy.backpressure,
+                    maxConcurrentOffers = 2)
+    .toMat(BroadcastHub.sink)(Keep.left)
+    .run()
+
+  it must "complete the remix" in { case (clientA, clientB, coordinator) =>
+    for {
+      addrA <- clientA.vortexWallet.getNewAddress(
+        coordinator.roundParams.outputType)
+
+      addrB <- clientB.vortexWallet.getNewAddress(
+        coordinator.roundParams.outputType)
+
+      _ <- clientA.askNonce()
+      _ <- clientB.askNonce()
+      // don't select all coins
+      utxosA <- clientA.listCoins().map(c => Random.shuffle(c).take(1))
+      _ = clientA.queueCoins(utxosA.map(_.outputReference), addrA)
+      utxosB <- clientB.listCoins().map(c => Random.shuffle(c).take(1))
+      _ = clientB.queueCoins(utxosB.map(_.outputReference), addrB)
+
+      txId <- coordinator.completedTxP.future.map(_.txIdBE)
+      nextCoordinator <- coordinator.nextCoordinatorP.future
+
+      addrA <- clientA.vortexWallet.getNewAddress(
+        nextCoordinator.roundParams.outputType)
+
+      addrB <- clientB.vortexWallet.getNewAddress(
+        nextCoordinator.roundParams.outputType)
+
+      _ <- TestAsyncUtil.awaitCondition(
+        () => {
+          clientA.getCurrentRoundDetails.order == KnownRound.order &&
+            clientB.getCurrentRoundDetails.order == KnownRound.order
+        },
+        interval = interval,
+        maxTries = maxTries
+      )
+
+      _ <- clientA.askNonce()
+      _ <- clientB.askNonce()
+      // don't select all coins
+      utxosA <- clientA.listCoins().map { coins =>
+        coins
+          .filter(_.outPoint.txIdBE == txId)
+          .filter(_.amount == coordinator.config.roundAmount)
+      }
+      coinsA = Random.shuffle(utxosA.map(_.outputReference)).take(1)
+      _ = clientA.queueCoins(coinsA, addrA)
+
+      utxosB <- clientB.listCoins().map { coins =>
+        coins.filterNot(_.outPoint.txIdBE == txId)
+      }
+      coinsB = Random.shuffle(utxosB.map(_.outputReference)).take(1)
+      _ = clientB.queueCoins(coinsB, addrB)
+
+      // await completion of the round
+      _ <- nextCoordinator.completedTxP.future
+      _ <- nextCoordinator.nextCoordinatorP.future
+
+      roundDbs <- nextCoordinator.roundDAO.findAll()
+
+      coinsA <- clientA.listCoins()
+      coinsB <- clientB.listCoins()
+    } yield {
+      assert(roundDbs.size >= 3)
+
+      val changeA = coinsA.filter(_.isChange)
+      assert(changeA.size == 1, s"${changeA.size} != 1")
+      assert(changeA.forall(_.anonSet == 1))
+
+      val changeB = coinsB.filter(_.isChange)
+      assert(changeB.size == 2, s"${changeB.size} != 2")
+      assert(changeB.forall(_.anonSet == 1))
+
+      assert(coinsA.count(_.anonSet == 3) == 1)
+      assert(coinsB.count(_.anonSet == 2) == 2)
+    }
+  }
+}

--- a/client-server-test/src/test/scala/com/lnvortex/server/RemixTest.scala
+++ b/client-server-test/src/test/scala/com/lnvortex/server/RemixTest.scala
@@ -40,20 +40,20 @@ class RemixTest
                                  clientB,
                                  coordinator)
 
-      _ <- coordinator.newRound()
-      _ = clientA.setRound(coordinator.roundParams)
-      _ = clientB.setRound(coordinator.roundParams)
+      nextCoordinator <- coordinator.nextCoordinatorP.future
+      _ <- clientA.setRound(nextCoordinator.roundParams)
+      _ <- clientB.setRound(nextCoordinator.roundParams)
 
       _ <- completeOnChainRound(Some(tx.txIdBE),
                                 peerId,
                                 peerId,
                                 clientA,
                                 clientB,
-                                coordinator)
+                                nextCoordinator)
 
       _ <- TestAsyncUtil.nonBlockingSleep(5.seconds)
 
-      roundDbs <- coordinator.roundDAO.findAll()
+      roundDbs <- nextCoordinator.roundDAO.findAll()
 
       coinsA <- clientA.listCoins()
       coinsB <- clientB.listCoins()

--- a/client-test/src/test/scala/com/lnvortex/client/VortexClientTest.scala
+++ b/client-test/src/test/scala/com/lnvortex/client/VortexClientTest.scala
@@ -39,11 +39,11 @@ class VortexClientTest extends VortexClientFixture {
 
   it must "fail to process an unknown version AskRoundParameters" in {
     vortexClient =>
-      forAll(
+      forAllAsync(
         NumberGenerator.uInt16
           .map(_.toInt)
           .suchThat(!knownVersions.contains(_))) { version =>
-        assertThrows[RuntimeException](
+        recoverToSucceededIf[RuntimeException](
           vortexClient.setRound(roundParams.copy(version = version)))
       }
   }

--- a/client/src/main/scala/com/lnvortex/client/networking/VortexHttpClient.scala
+++ b/client/src/main/scala/com/lnvortex/client/networking/VortexHttpClient.scala
@@ -256,7 +256,6 @@ trait VortexHttpClient[+V <: VortexWalletApi] { self: VortexClient[V] =>
           }
           logger.info(s"Received round details ${round.roundId.hex}")
           setRound(round)
-          Future.unit
         }
       case bm: BinaryMessage =>
         // ignore binary messages but drain content to avoid the stream being clogged
@@ -272,7 +271,6 @@ trait VortexHttpClient[+V <: VortexWalletApi] { self: VortexClient[V] =>
       case adv: RoundParameters =>
         logger.info(s"Received round details ${adv.roundId.hex}")
         setRound(adv)
-        Future.unit
       case NonceMessage(schnorrNonce) =>
         storeNonce(schnorrNonce)
         Future.unit

--- a/coordinator/rpc-server/src/main/scala/com/lnvortex/coordinator/rpc/LnVortexAppConfig.scala
+++ b/coordinator/rpc-server/src/main/scala/com/lnvortex/coordinator/rpc/LnVortexAppConfig.scala
@@ -3,7 +3,6 @@ package com.lnvortex.coordinator.rpc
 import akka.actor.ActorSystem
 import com.lnvortex.coordinator.config.LnVortexRpcServerConfig
 import com.lnvortex.server.config.VortexCoordinatorAppConfig
-import com.lnvortex.server.coordinator.VortexCoordinator
 import com.typesafe.config.Config
 import org.bitcoins.commons.config._
 import org.bitcoins.rpc.client.common._
@@ -14,7 +13,7 @@ import org.bitcoins.rpc.client.v20.BitcoindV20RpcClient
 import org.bitcoins.rpc.client.v21.BitcoindV21RpcClient
 import org.bitcoins.rpc.client.v22.BitcoindV22RpcClient
 import org.bitcoins.rpc.client.v23.BitcoindV23RpcClient
-import org.bitcoins.rpc.config.{BitcoindInstance, BitcoindRpcAppConfig}
+import org.bitcoins.rpc.config._
 
 import java.nio.file.{Path, Paths}
 import scala.concurrent.{ExecutionContext, Future}
@@ -66,8 +65,6 @@ case class LnVortexAppConfig(
       }
     case None => BitcoindRpcClient(instance)
   }
-
-  lazy val coordinator: VortexCoordinator = VortexCoordinator(bitcoind)
 
 }
 

--- a/server/src/main/scala/com/lnvortex/server/networking/CoordinatorRoutes.scala
+++ b/server/src/main/scala/com/lnvortex/server/networking/CoordinatorRoutes.scala
@@ -18,10 +18,21 @@ import play.api.libs.json._
 import scala.concurrent._
 import scala.util._
 
-case class CoordinatorRoutes(coordinator: VortexCoordinator)(implicit
+class CoordinatorRoutes(var coordinator: VortexCoordinator)(implicit
     system: ActorSystem)
     extends Logging {
   implicit val ec: ExecutionContext = system.dispatcher
+
+  // Need to switch coordinator when given a new one
+  def prepareNextCoordinator(): Unit = {
+    coordinator.nextCoordinatorP.future.map { nextCoordinator =>
+      coordinator = nextCoordinator
+      prepareNextCoordinator()
+    }
+    ()
+  }
+
+  prepareNextCoordinator()
 
   private val pingRoute = path("ping") {
     get {

--- a/server/src/main/scala/com/lnvortex/server/networking/VortexHttpServer.scala
+++ b/server/src/main/scala/com/lnvortex/server/networking/VortexHttpServer.scala
@@ -23,7 +23,6 @@ class VortexHttpServer(coordinator: VortexCoordinator)(implicit
     } else {
       val bindAddress = coordinator.config.listenAddress
       for {
-        _ <- coordinator.start()
         onionAddress <- coordinator.config.torParams match {
           case Some(params) =>
             TorController
@@ -36,7 +35,7 @@ class VortexHttpServer(coordinator: VortexCoordinator)(implicit
               .map(Some(_))
           case None => Future.successful(None)
         }
-        routes = CoordinatorRoutes(coordinator).topLevelRoute
+        routes = new CoordinatorRoutes(coordinator).topLevelRoute
         bind <- Http()
           .newServerAt(bindAddress.getHostName, bindAddress.getPort)
           .bind(routes)

--- a/testkit/src/main/scala/com/lnvortex/testkit/ClientServerPairFixture.scala
+++ b/testkit/src/main/scala/com/lnvortex/testkit/ClientServerPairFixture.scala
@@ -49,7 +49,7 @@ trait ClientServerPairFixture
         for {
           _ <- serverConf.start()
           bitcoind <- cachedBitcoindWithFundsF
-          coordinator = VortexCoordinator(bitcoind)
+          coordinator <- VortexCoordinator.initialize(bitcoind)
           server = new VortexHttpServer(coordinator)
           _ <- server.start()
           addr <- server.bindingP.future.map(_.localAddress)
@@ -88,7 +88,7 @@ trait ClientServerPairFixture
           _ <- client.config.stop()
 
           _ <- coordinator.config.dropAll().map(_ => coordinator.config.clean())
-          _ <- coordinator.stop()
+          _ = coordinator.stop()
           _ <- coordinator.config.stop()
         } yield {
           val directory = new Directory(coordinator.config.baseDatadir.toFile)

--- a/testkit/src/main/scala/com/lnvortex/testkit/DualClientFixture.scala
+++ b/testkit/src/main/scala/com/lnvortex/testkit/DualClientFixture.scala
@@ -50,7 +50,7 @@ trait DualClientFixture
         for {
           _ <- serverConf.start()
           bitcoind <- cachedBitcoindWithFundsF
-          coordinator = VortexCoordinator(bitcoind)
+          coordinator <- VortexCoordinator.initialize(bitcoind)
           server = new VortexHttpServer(coordinator)
           _ <- server.start()
           addr <- server.bindingP.future.map(_.localAddress)
@@ -100,7 +100,7 @@ trait DualClientFixture
           _ <- clientB.config.stop()
 
           _ <- coordinator.config.dropAll().map(_ => coordinator.config.clean())
-          _ <- coordinator.stop()
+          _ = coordinator.stop()
           _ <- coordinator.config.stop()
         } yield {
           val directory = new Directory(coordinator.config.baseDatadir.toFile)

--- a/testkit/src/main/scala/com/lnvortex/testkit/HttpTestFixture.scala
+++ b/testkit/src/main/scala/com/lnvortex/testkit/HttpTestFixture.scala
@@ -31,8 +31,7 @@ trait HttpTestFixture
         for {
           _ <- serverConf.start()
           bitcoind <- cachedBitcoindWithFundsF
-          coordinator = VortexCoordinator(bitcoind)
-          _ <- coordinator.start()
+          coordinator <- VortexCoordinator.initialize(bitcoind)
           server = new VortexHttpServer(coordinator)
           _ <- server.start()
           addr <- server.bindingP.future.map(_.localAddress)
@@ -58,7 +57,7 @@ trait HttpTestFixture
           _ <- client.config.stop()
 
           _ <- coordinator.config.dropAll().map(_ => coordinator.config.clean())
-          _ <- coordinator.stop()
+          _ = coordinator.stop()
           _ <- coordinator.config.stop()
         } yield {
           val directory = new Directory(coordinator.config.baseDatadir.toFile)

--- a/testkit/src/main/scala/com/lnvortex/testkit/VortexCoordinatorFixture.scala
+++ b/testkit/src/main/scala/com/lnvortex/testkit/VortexCoordinatorFixture.scala
@@ -26,8 +26,7 @@ trait VortexCoordinatorFixture
           addr <- bitcoind.getNewAddress
           _ <- bitcoind.generateToAddress(6, addr)
           _ <- conf.start()
-          coordinator = VortexCoordinator(bitcoind)
-          _ <- coordinator.start()
+          coordinator <- VortexCoordinator.initialize(bitcoind)
         } yield coordinator
       },
       { coordinator =>
@@ -35,7 +34,7 @@ trait VortexCoordinatorFixture
 
         for {
           _ <- config.dropAll().map(_ => config.clean())
-          _ <- coordinator.stop()
+          _ = coordinator.stop()
           _ <- coordinator.config.stop()
         } yield {
           val directory = new Directory(coordinator.config.baseDatadir.toFile)


### PR DESCRIPTION
Refactors the coordinator to be more idomatic, now uses immuatable variables and creates a new version of itself after every round.

Adds a `RemixNetworkingTest` which should show that this does not break any current functionality with creating new rounds.