### PR TITLE
Make nextCoordinatorP private, only expose the future

### DIFF
--- a/client-server-test/src/test/scala/com/lnvortex/server/DualClientTest.scala
+++ b/client-server-test/src/test/scala/com/lnvortex/server/DualClientTest.scala
@@ -138,7 +138,7 @@ class DualClientTest
         _ <- TestAsyncUtil.nonBlockingSleep(3.seconds)
 
         restartMsg <- coordinator.reconcileRound().map(_.head)
-        newCoordinator <- coordinator.nextCoordinatorP.future
+        newCoordinator <- coordinator.getNextCoordinator
 
         _ <- TestAsyncUtil.nonBlockingSleep(3.seconds)
 
@@ -171,7 +171,7 @@ class DualClientTest
         signedA <- client.validateAndSignPsbt(psbt)
 
         _ <- newCoordinator.registerPSBTSignatures(peerIdA, signedA)
-        tx <- newCoordinator.completedTxP.future
+        tx <- newCoordinator.getCompletedTx
         _ <- client.completeRound(tx)
 
         inputUtxos = all.filter(t =>

--- a/client-server-test/src/test/scala/com/lnvortex/server/RemixNetworkingTest.scala
+++ b/client-server-test/src/test/scala/com/lnvortex/server/RemixNetworkingTest.scala
@@ -51,8 +51,8 @@ class RemixNetworkingTest
       utxosB <- clientB.listCoins().map(c => Random.shuffle(c).take(1))
       _ = clientB.queueCoins(utxosB.map(_.outputReference), addrB)
 
-      txId <- coordinator.completedTxP.future.map(_.txIdBE)
-      nextCoordinator <- coordinator.nextCoordinatorP.future
+      txId <- coordinator.getCompletedTx.map(_.txIdBE)
+      nextCoordinator <- coordinator.getNextCoordinator
 
       addrA <- clientA.vortexWallet.getNewAddress(
         nextCoordinator.roundParams.outputType)
@@ -87,8 +87,8 @@ class RemixNetworkingTest
       _ = clientB.queueCoins(coinsB, addrB)
 
       // await completion of the round
-      _ <- nextCoordinator.completedTxP.future
-      _ <- nextCoordinator.nextCoordinatorP.future
+      _ <- nextCoordinator.getCompletedTx
+      _ <- nextCoordinator.getNextCoordinator
 
       roundDbs <- nextCoordinator.roundDAO.findAll()
 

--- a/client-server-test/src/test/scala/com/lnvortex/server/RemixTest.scala
+++ b/client-server-test/src/test/scala/com/lnvortex/server/RemixTest.scala
@@ -40,7 +40,7 @@ class RemixTest
                                  clientB,
                                  coordinator)
 
-      nextCoordinator <- coordinator.nextCoordinatorP.future
+      nextCoordinator <- coordinator.getNextCoordinator
       _ <- clientA.setRound(nextCoordinator.roundParams)
       _ <- clientB.setRound(nextCoordinator.roundParams)
 

--- a/server/src/main/scala/com/lnvortex/server/coordinator/VortexCoordinator.scala
+++ b/server/src/main/scala/com/lnvortex/server/coordinator/VortexCoordinator.scala
@@ -64,8 +64,10 @@ class VortexCoordinator private (
 
   lazy val publicKey: SchnorrPublicKey = km.publicKey
 
-  val nextCoordinatorP: Promise[VortexCoordinator] =
+  private val nextCoordinatorP: Promise[VortexCoordinator] =
     Promise[VortexCoordinator]()
+
+  def getNextCoordinator: Future[VortexCoordinator] = nextCoordinatorP.future
 
   def getCurrentRoundId: DoubleSha256Digest = roundId
 
@@ -140,8 +142,10 @@ class VortexCoordinator private (
   private val signedPMap: mutable.Map[Sha256Digest, Boolean] =
     mutable.Map.empty
 
-  val completedTxP: Promise[Transaction] =
+  private val completedTxP: Promise[Transaction] =
     Promise[Transaction]()
+
+  def getCompletedTx: Future[Transaction] = completedTxP.future
 
   private def disconnectPeers(): Unit = {
     if (connectionHandlerMap.values.nonEmpty) {

--- a/server/src/main/scala/com/lnvortex/server/networking/CoordinatorRoutes.scala
+++ b/server/src/main/scala/com/lnvortex/server/networking/CoordinatorRoutes.scala
@@ -25,7 +25,7 @@ class CoordinatorRoutes(var coordinator: VortexCoordinator)(implicit
 
   // Need to switch coordinator when given a new one
   def prepareNextCoordinator(): Unit = {
-    coordinator.nextCoordinatorP.future.map { nextCoordinator =>
+    coordinator.getNextCoordinator.map { nextCoordinator =>
       coordinator = nextCoordinator
       prepareNextCoordinator()
     }

--- a/server/src/main/scala/com/lnvortex/server/networking/VortexHttpServer.scala
+++ b/server/src/main/scala/com/lnvortex/server/networking/VortexHttpServer.scala
@@ -15,7 +15,10 @@ class VortexHttpServer(coordinator: VortexCoordinator)(implicit
     with Logging {
   implicit val executionContext: ExecutionContext = system.dispatcher
 
-  val bindingP: Promise[Http.ServerBinding] = Promise[Http.ServerBinding]()
+  private val bindingP: Promise[Http.ServerBinding] =
+    Promise[Http.ServerBinding]()
+
+  def getBinding: Future[Http.ServerBinding] = bindingP.future
 
   override def start(): Future[Unit] = {
     if (bindingP.isCompleted) {

--- a/testkit/src/main/scala/com/lnvortex/testkit/ClientServerPairFixture.scala
+++ b/testkit/src/main/scala/com/lnvortex/testkit/ClientServerPairFixture.scala
@@ -55,7 +55,7 @@ trait ClientServerPairFixture
           coordinator <- VortexCoordinator.initialize(bitcoind)
           server = new VortexHttpServer(coordinator)
           _ <- server.start()
-          addr <- server.bindingP.future.map(_.localAddress)
+          addr <- server.getBinding.map(_.localAddress)
 
           _ = assert(serverConf.outputScriptType == outputScriptType)
 

--- a/testkit/src/main/scala/com/lnvortex/testkit/ClientServerTestUtils.scala
+++ b/testkit/src/main/scala/com/lnvortex/testkit/ClientServerTestUtils.scala
@@ -249,7 +249,7 @@ trait ClientServerTestUtils {
       psbt <- signPSBT(peerId, client, coordinator, peerLnd)
 
       _ <- coordinator.registerPSBTSignatures(peerId, psbt)
-      tx <- coordinator.completedTxP.future
+      tx <- coordinator.getCompletedTx
 
       _ <- client.completeRound(tx)
 
@@ -281,7 +281,7 @@ trait ClientServerTestUtils {
       psbt <- signPSBT(peerId, client, coordinator)
 
       _ <- coordinator.registerPSBTSignatures(peerId, psbt)
-      tx <- coordinator.completedTxP.future
+      tx <- coordinator.getCompletedTx
 
       _ <- client.completeRound(tx)
 
@@ -331,7 +331,7 @@ trait ClientServerTestUtils {
       _ <- coordinator.registerPSBTSignatures(peerIdA, psbtA)
       _ <- coordinator.registerPSBTSignatures(peerIdB, psbtB)
 
-      tx <- coordinator.completedTxP.future
+      tx <- coordinator.getCompletedTx
 
       _ <- clientA.completeRound(tx)
       _ <- clientB.completeRound(tx)
@@ -456,7 +456,7 @@ trait ClientServerTestUtils {
       _ <- coordinator.registerPSBTSignatures(peerIdA, signedA)
       _ <- coordinator.registerPSBTSignatures(peerIdB, signedB)
 
-      tx <- coordinator.completedTxP.future
+      tx <- coordinator.getCompletedTx
 
       inputUtxos = (utxosA ++ utxosB).filter(t =>
         tx.inputs.map(_.previousOutput).contains(t.outPoint))

--- a/testkit/src/main/scala/com/lnvortex/testkit/DualClientFixture.scala
+++ b/testkit/src/main/scala/com/lnvortex/testkit/DualClientFixture.scala
@@ -55,7 +55,7 @@ trait DualClientFixture
           coordinator <- VortexCoordinator.initialize(bitcoind)
           server = new VortexHttpServer(coordinator)
           _ <- server.start()
-          addr <- server.bindingP.future.map(_.localAddress)
+          addr <- server.getBinding.map(_.localAddress)
 
           _ = assert(serverConf.outputScriptType == outputScriptType)
 

--- a/testkit/src/main/scala/com/lnvortex/testkit/HttpTestFixture.scala
+++ b/testkit/src/main/scala/com/lnvortex/testkit/HttpTestFixture.scala
@@ -35,7 +35,7 @@ trait HttpTestFixture
           coordinator <- VortexCoordinator.initialize(bitcoind)
           server = new VortexHttpServer(coordinator)
           _ <- server.start()
-          addr <- server.bindingP.future.map(_.localAddress)
+          addr <- server.getBinding.map(_.localAddress)
 
           _ <- clientConfig.start()
 


### PR DESCRIPTION
Only the coordinator should be completing this promise, so we should have it private. The future is what the other parts of the library want.

Did the same with completedTxP