### PR TITLE
Correctly verify fees & script types as client

### DIFF
--- a/client/src/main/scala/com/lnvortex/client/VortexClientException.scala
+++ b/client/src/main/scala/com/lnvortex/client/VortexClientException.scala
@@ -16,6 +16,12 @@ object VortexClientException {
   class InvalidChangeOutputException(private val reason: String)
       extends VortexClientException(reason)
 
+  class InvalidInputTypeException(private val reason: String)
+      extends VortexClientException(reason)
+
+  class InvalidOutputTypeException(private val reason: String)
+      extends VortexClientException(reason)
+
   class MissingInputsException(private val reason: String)
       extends VortexClientException(reason)
 

--- a/lnd/src/main/scala/com/lnvortex/lnd/LndVortexWallet.scala
+++ b/lnd/src/main/scala/com/lnvortex/lnd/LndVortexWallet.scala
@@ -247,8 +247,7 @@ case class LndVortexWallet(lndRpcClient: LndRpcClient)(implicit
                 alias = alias,
                 outPoint = outPoint,
                 remotePubkey = NodeId(channel.remoteNodePub),
-                shortChannelId =
-                  ShortChannelId(UInt64.zero), // fixme make optional?
+                shortChannelId = ShortChannelId(UInt64.zero),
                 public = !channel.`private`,
                 amount = Satoshis(channel.capacity),
                 active = false,


### PR DESCRIPTION
Previously we would estimate the fee rate incorrectly because the transaction had no signatures as well as wouldn't verify that the input & output types weren't different than what we expected