### PR TITLE
Skip creating torKeys folder if just tor proxy is enabled

### DIFF
--- a/server/src/main/scala/com/lnvortex/server/config/VortexCoordinatorAppConfig.scala
+++ b/server/src/main/scala/com/lnvortex/server/config/VortexCoordinatorAppConfig.scala
@@ -278,7 +278,7 @@ case class VortexCoordinatorAppConfig(
 
     // initialize tor keys
     if (
-      torConf.enabled && !torParams
+      torParams.isDefined && !torParams
         .map(_.privateKeyPath)
         .exists(Files.exists(_))
     ) {


### PR DESCRIPTION
If the tor proxy was enabled and the tor service was not this would result in a none.get