### PR TITLE
Make peer node id easier to copy from terminal

### DIFF
--- a/develop/src/main/scala/com/lnvortex/develop/CreateLocalDevEnvironment.scala
+++ b/develop/src/main/scala/com/lnvortex/develop/CreateLocalDevEnvironment.scala
@@ -74,7 +74,7 @@ object CreateLocalDevEnvironment extends App with Logging {
 
     nodeId <- peerLnd.nodeId
     _ = logger.info(s"========================")
-    _ = logger.info(s"Peer node id=$nodeId")
+    _ = logger.info(s"Peer node id: $nodeId")
     _ = logger.info(s"========================")
 
     _ <- coordConfig.start()


### PR DESCRIPTION
When I clicked it, it would highlight `id=02...`