### PR TITLE
Add `jlink` support

### DIFF
--- a/app/rpc-server/src/universal/rpc-server-extra-startup-script.sh
+++ b/app/rpc-server/src/universal/rpc-server-extra-startup-script.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+
+if [[ -z "$DISABLE_JLINK" ]]; then
+  if test -f "jre/bin/java"; then
+    if [[ "$OS" == "OSX" ]]; then
+      #mac doesn't allow random binaries to be executable
+      #remove the quarantine attribute so java is executable on mac
+      xattr -d com.apple.quarantine jre/bin/java
+    fi
+    chmod +x jre/bin/java #make sure java is executable
+  fi
+
+  if test -f "../jre/bin/java" ; then
+    if [[ "$OS" == "OSX" ]]; then
+      #mac doesn't allow random binaries to be executable
+      #remove the quarantine attribute so java is executable on mac
+      xattr -d com.apple.quarantine ../jre/bin/java
+    fi
+    chmod +x ../jre/bin/java #make sure java is executable
+  fi
+fi
+
+chip=$(uname -m)
+
+get_java_no_jlink() {
+  if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
+    echo "$JAVA_HOME/bin/java"
+  else
+    echo "java"
+  fi
+}
+
+if [[ -n "$DISABLE_JLINK" ]]; then
+  echo "jlink disabled by the DISABLE_JLINK environment variable, defaulting to JAVA_HOME for java"
+  # java_cmd is overrode in process_args when -java-home is used
+  declare java_cmd=$(get_java_no_jlink)
+
+  # if configuration files exist, prepend their contents to $@ so it can be processed by this runner
+  [[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file") "$@"
+
+  run "$@"
+fi
+
+if [[ $chip == "arm64" || $chip == "aarch64" ]]; then
+  # This is needed as a hack for now
+  # This replaces overrides how sbt native packager finds java
+  # on users machines when the user is running arm64.
+  # This is needed because we don't have access to a CI environment with arm64
+  # and the jlink jre we ship is broken because its built against x86
+  # this simply copies the 'get_java` bash function and removes the first
+  # check to see if there is a bundled_jvm built by jlink if the detected
+  # computer arch is arm64 or aarch64. This means a user if they are running
+  # arm64 / aarch64 will need to provide their own jre
+  echo "Removing jre as its not linked correctly on ARM machines, see https://github.com/bitcoin-s/bitcoin-s/issues/4369!"
+
+  # java_cmd is overrode in process_args when -java-home is used
+  declare java_cmd=$(get_java_no_jlink)
+
+  # if configuration files exist, prepend their contents to $@ so it can be processed by this runner
+  [[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file") "$@"
+
+  run "$@"
+fi

--- a/build.sbt
+++ b/build.sbt
@@ -124,11 +124,13 @@ lazy val rpcServer = project
   .settings(CommonSettings.appSettings: _*)
   .settings(CommonSettings.dockerSettings: _*)
   .settings(CommonSettings.dockerBuildxSettings: _*)
+  .settings(jlinkIgnoreMissingDependency := CommonSettings.jlinkIgnore)
   .settings(libraryDependencies ++= Deps.rpcServer)
   .settings(name := "vortexd")
   .dependsOn(client, lnd, clightning, bitcoind, config)
   .enablePlugins(
     JavaAppPackaging,
+    JlinkPlugin,
     DockerPlugin,
     // JlinkPlugin,
     // needed for windows, else we have the 'The input line is too long` on windows OS
@@ -156,10 +158,12 @@ lazy val coordinatorRpc = project
   .settings(CommonSettings.appSettings: _*)
   .settings(CommonSettings.dockerSettings: _*)
   .settings(CommonSettings.dockerBuildxSettings: _*)
+  .settings(jlinkIgnoreMissingDependency := CommonSettings.jlinkIgnore)
   .settings(libraryDependencies ++= Deps.coordinatorRpc)
   .dependsOn(server, coordinatorConfig)
   .enablePlugins(
     JavaAppPackaging,
+    JlinkPlugin,
     DockerPlugin,
     // JlinkPlugin,
     // needed for windows, else we have the 'The input line is too long` on windows OS

--- a/build.sbt
+++ b/build.sbt
@@ -126,6 +126,7 @@ lazy val rpcServer = project
   .settings(CommonSettings.dockerBuildxSettings: _*)
   .settings(jlinkIgnoreMissingDependency := CommonSettings.jlinkIgnore)
   .settings(libraryDependencies ++= Deps.rpcServer)
+  .settings(bashScriptExtraDefines ++= IO.readLines(baseDirectory.value / "src" / "universal" / "rpc-server-extra-startup-script.sh"))
   .settings(name := "vortexd")
   .dependsOn(client, lnd, clightning, bitcoind, config)
   .enablePlugins(
@@ -158,6 +159,7 @@ lazy val coordinatorRpc = project
   .settings(CommonSettings.appSettings: _*)
   .settings(CommonSettings.dockerSettings: _*)
   .settings(CommonSettings.dockerBuildxSettings: _*)
+  .settings(bashScriptExtraDefines ++= IO.readLines(baseDirectory.value / "src" / "universal" / "coordinator-rpc-server-extra-startup-script.sh"))
   .settings(jlinkIgnoreMissingDependency := CommonSettings.jlinkIgnore)
   .settings(libraryDependencies ++= Deps.coordinatorRpc)
   .dependsOn(server, coordinatorConfig)

--- a/coordinator/rpc-server/src/universal/coordinator-rpc-server-extra-startup-script.sh
+++ b/coordinator/rpc-server/src/universal/coordinator-rpc-server-extra-startup-script.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+
+if [[ -z "$DISABLE_JLINK" ]]; then
+  if test -f "jre/bin/java"; then
+    if [[ "$OS" == "OSX" ]]; then
+      #mac doesn't allow random binaries to be executable
+      #remove the quarantine attribute so java is executable on mac
+      xattr -d com.apple.quarantine jre/bin/java
+    fi
+    chmod +x jre/bin/java #make sure java is executable
+  fi
+
+  if test -f "../jre/bin/java" ; then
+    if [[ "$OS" == "OSX" ]]; then
+      #mac doesn't allow random binaries to be executable
+      #remove the quarantine attribute so java is executable on mac
+      xattr -d com.apple.quarantine ../jre/bin/java
+    fi
+    chmod +x ../jre/bin/java #make sure java is executable
+  fi
+fi
+
+chip=$(uname -m)
+
+get_java_no_jlink() {
+  if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
+    echo "$JAVA_HOME/bin/java"
+  else
+    echo "java"
+  fi
+}
+
+if [[ -n "$DISABLE_JLINK" ]]; then
+  echo "jlink disabled by the DISABLE_JLINK environment variable, defaulting to JAVA_HOME for java"
+  # java_cmd is overrode in process_args when -java-home is used
+  declare java_cmd=$(get_java_no_jlink)
+
+  # if configuration files exist, prepend their contents to $@ so it can be processed by this runner
+  [[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file") "$@"
+
+  run "$@"
+fi
+
+if [[ $chip == "arm64" || $chip == "aarch64" ]]; then
+  # This is needed as a hack for now
+  # This replaces overrides how sbt native packager finds java
+  # on users machines when the user is running arm64.
+  # This is needed because we don't have access to a CI environment with arm64
+  # and the jlink jre we ship is broken because its built against x86
+  # this simply copies the 'get_java` bash function and removes the first
+  # check to see if there is a bundled_jvm built by jlink if the detected
+  # computer arch is arm64 or aarch64. This means a user if they are running
+  # arm64 / aarch64 will need to provide their own jre
+  echo "Removing jre as its not linked correctly on ARM machines, see https://github.com/bitcoin-s/bitcoin-s/issues/4369!"
+
+  # java_cmd is overrode in process_args when -java-home is used
+  declare java_cmd=$(get_java_no_jlink)
+
+  # if configuration files exist, prepend their contents to $@ so it can be processed by this runner
+  [[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file") "$@"
+
+  run "$@"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
 
       VORTEX_LND_RPC_URI: "$APP_LIGHTNING_NODE_IP:$APP_LIGHTNING_NODE_GRPC_PORT"
       VORTEX_LND_DATADIR: "/lnd/"
+      DISABLE_JLINK: "1"
     ports:
       - "2522:2522"
       - "12522:12522"

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -3,6 +3,7 @@
 import com.typesafe.sbt.SbtNativePackager.Docker
 import com.typesafe.sbt.SbtNativePackager.autoImport.packageName
 import com.typesafe.sbt.packager.Keys._
+import com.typesafe.sbt.packager.archetypes.jlink.JlinkPlugin.autoImport.JlinkIgnore
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.dockerBaseImage
 import sbt.Keys._
 import sbt.{Def, _}
@@ -267,4 +268,110 @@ object CommonSettings {
 
   lazy val binariesPath: Path =
     Paths.get(Properties.userHome, ".bitcoin-s", "binaries")
+
+
+  //see https://www.scala-sbt.org/sbt-native-packager/archetypes/jlink_plugin.html?highlight=jlinkignore#jlink-plugin
+  val jlinkIgnore = {
+    val deps = Vector(
+      //direct_dependency -> transitive dependency
+      "com.zaxxer.hikari.hibernate" -> "org.hibernate.service.spi",
+      "com.zaxxer.hikari.metrics.dropwizard" -> "com.codahale.metrics.health",
+      "com.zaxxer.hikari.metrics.micrometer" -> "io.micrometer.core.instrument",
+      "com.zaxxer.hikari.metrics.prometheus" -> "io.prometheus.client",
+      "com.zaxxer.hikari.pool" -> "com.codahale.metrics.health",
+      "com.zaxxer.hikari.pool" -> "io.micrometer.core.instrument",
+      "com.zaxxer.hikari.util" -> "javassist",
+      "com.zaxxer.hikari.util" -> "javassist.bytecode",
+      "monix.execution.misc" -> "scala.tools.nsc",
+      "org.flywaydb.core.api.configuration" -> "software.amazon.awssdk.services.s3",
+      "org.flywaydb.core.internal.database.oracle" -> "oracle.jdbc",
+      "org.flywaydb.core.internal.logging.apachecommons" -> "org.apache.commons.logging",
+      "org.flywaydb.core.internal.logging.log4j2" -> "org.apache.logging.log4j",
+      "org.flywaydb.core.internal.resource.s3" -> "software.amazon.awssdk.awscore.exception",
+      "org.flywaydb.core.internal.resource.s3" -> "software.amazon.awssdk.core",
+      "org.flywaydb.core.internal.resource.s3" -> "software.amazon.awssdk.services.s3",
+      "org.flywaydb.core.internal.resource.s3" -> "software.amazon.awssdk.services.s3.model",
+      "org.flywaydb.core.internal.scanner.classpath" -> "org.osgi.framework",
+      "org.flywaydb.core.internal.scanner.classpath.jboss" -> "org.jboss.vfs",
+      "org.flywaydb.core.internal.scanner.cloud.s3" -> "software.amazon.awssdk.core.exception",
+      "org.flywaydb.core.internal.scanner.cloud.s3" -> "software.amazon.awssdk.services.s3",
+      "org.flywaydb.core.internal.scanner.cloud.s3" -> "software.amazon.awssdk.services.s3.model",
+      "org.flywaydb.core.internal.util" -> "com.google.gson",
+      "org.flywaydb.core.internal.util" -> "com.google.gson.reflect",
+      "org.postgresql.osgi" -> "org.osgi.framework",
+      "org.postgresql.osgi" -> "org.osgi.service.jdbc",
+      "org.postgresql.sspi" -> "com.sun.jna",
+      "org.postgresql.sspi" -> "com.sun.jna.platform.win32",
+      "org.postgresql.sspi" -> "com.sun.jna.ptr",
+      "org.postgresql.sspi" -> "com.sun.jna.win32",
+      "org.postgresql.sspi" -> "waffle.windows.auth",
+      "org.postgresql.sspi" -> "waffle.windows.auth.impl",
+      "scala.meta.internal.svm_subs" -> "com.oracle.svm.core.annotate",
+      "shapeless" -> "scala.reflect.macros.contexts",
+      "shapeless" -> "scala.tools.nsc",
+      "shapeless" -> "scala.tools.nsc.ast",
+      "shapeless" -> "scala.tools.nsc.typechecker",
+
+      "akka.grpc.javadsl" -> "ch.megard.akka.http.cors.javadsl",
+    "akka.grpc.javadsl" -> "ch.megard.akka.http.cors.javadsl.settings",
+    "akka.grpc.javadsl" -> "ch.megard.akka.http.cors.scaladsl.settings",
+    "akka.grpc.scaladsl" -> "ch.megard.akka.http.cors.scaladsl",
+    "akka.grpc.scaladsl" -> "ch.megard.akka.http.cors.scaladsl.model",
+    "akka.grpc.scaladsl" -> "ch.megard.akka.http.cors.scaladsl.settings",
+    "ch.qos.logback.classic" -> "jakarta.servlet.http",
+    "ch.qos.logback.classic.helpers" -> "jakarta.servlet",
+    "ch.qos.logback.classic.helpers" -> "jakarta.servlet.http",
+    "ch.qos.logback.classic.selector.servlet" -> "jakarta.servlet",
+    "ch.qos.logback.classic.servlet" -> "jakarta.servlet",
+    "ch.qos.logback.core.boolex" -> "org.codehaus.janino",
+    "ch.qos.logback.core.joran.conditional" -> "org.codehaus.commons.compiler",
+    "ch.qos.logback.core.joran.conditional" -> "org.codehaus.janino",
+    "ch.qos.logback.core.net" -> "jakarta.mail",
+    "ch.qos.logback.core.net" -> "jakarta.mail.internet",
+    "ch.qos.logback.core.status" -> "jakarta.servlet",
+    "ch.qos.logback.core.status" -> "jakarta.servlet.http",
+    "com.zaxxer.hikari" -> "com.codahale.metrics.health",
+    "com.zaxxer.hikari.hibernate" -> "org.hibernate",
+    "com.zaxxer.hikari.hibernate" -> "org.hibernate.cfg",
+    "com.zaxxer.hikari.hibernate" -> "org.hibernate.engine.jdbc.connections.spi",
+    "com.zaxxer.hikari.hibernate" -> "org.hibernate.service",
+    "io.grpc.netty.shaded.io.netty.handler.codec.compression" -> "com.aayushatharva.brotli4j",
+    "io.grpc.netty.shaded.io.netty.handler.codec.compression" -> "com.aayushatharva.brotli4j.decoder",
+    "io.grpc.netty.shaded.io.netty.handler.codec.compression" -> "com.aayushatharva.brotli4j.encoder",
+    "io.grpc.netty.shaded.io.netty.handler.codec.compression" -> "com.github.luben.zstd",
+    "io.grpc.netty.shaded.io.netty.handler.codec.compression" -> "com.jcraft.jzlib",
+    "io.grpc.netty.shaded.io.netty.handler.codec.compression" -> "com.ning.compress",
+    "io.grpc.netty.shaded.io.netty.handler.codec.compression" -> "com.ning.compress.lzf",
+    "io.grpc.netty.shaded.io.netty.handler.codec.compression" -> "com.ning.compress.lzf.util",
+    "io.grpc.netty.shaded.io.netty.handler.codec.compression" -> "lzma.sdk",
+    "io.grpc.netty.shaded.io.netty.handler.codec.compression" -> "lzma.sdk.lzma",
+    "io.grpc.netty.shaded.io.netty.handler.codec.compression" -> "net.jpountz.lz4",
+    "io.grpc.netty.shaded.io.netty.handler.codec.compression" -> "net.jpountz.xxhash",
+    "io.grpc.netty.shaded.io.netty.handler.codec.http" -> "com.aayushatharva.brotli4j.encoder",
+    "io.grpc.netty.shaded.io.netty.handler.codec.http2" -> "com.aayushatharva.brotli4j.encoder",
+    "io.grpc.netty.shaded.io.netty.handler.codec.marshalling" -> "org.jboss.marshalling",
+    "io.grpc.netty.shaded.io.netty.handler.codec.protobuf" -> "com.google.protobuf.nano",
+    "io.grpc.netty.shaded.io.netty.handler.codec.spdy" -> "com.jcraft.jzlib",
+    "io.grpc.netty.shaded.io.netty.handler.ssl" -> "org.conscrypt",
+    "io.grpc.netty.shaded.io.netty.handler.ssl" -> "org.eclipse.jetty.alpn",
+    "io.grpc.netty.shaded.io.netty.handler.ssl" -> "org.eclipse.jetty.npn",
+    "io.grpc.netty.shaded.io.netty.handler.ssl.util" -> "org.bouncycastle.cert",
+    "io.grpc.netty.shaded.io.netty.handler.ssl.util" -> "org.bouncycastle.cert.jcajce",
+    "io.grpc.netty.shaded.io.netty.handler.ssl.util" -> "org.bouncycastle.operator",
+    "io.grpc.netty.shaded.io.netty.handler.ssl.util" -> "org.bouncycastle.operator.jcajce",
+    "io.grpc.netty.shaded.io.netty.util" -> "com.oracle.svm.core.annotate",
+    "io.grpc.netty.shaded.io.netty.util.concurrent" -> "org.jetbrains.annotations",
+    "io.grpc.netty.shaded.io.netty.util.internal" -> "reactor.blockhound",
+    "io.grpc.netty.shaded.io.netty.util.internal" -> "reactor.blockhound.integration",
+    "io.grpc.netty.shaded.io.netty.util.internal.logging" -> "org.apache.commons.logging",
+    "io.grpc.netty.shaded.io.netty.util.internal.logging" -> "org.apache.log4j",
+    "io.grpc.netty.shaded.io.netty.util.internal.logging" -> "org.apache.logging.log4j",
+    "io.grpc.netty.shaded.io.netty.util.internal.logging" -> "org.apache.logging.log4j.message",
+    "io.grpc.netty.shaded.io.netty.util.internal.logging" -> "org.apache.logging.log4j.spi",
+    "io.grpc.netty.shaded.io.netty.util.internal.svm" -> "com.oracle.svm.core.annotate",
+     "com.thoughtworks.paranamer" -> "javax.inject"
+    )
+
+    JlinkIgnore.byPackagePrefix(deps:_*)
+  }
 }


### PR DESCRIPTION
fixes #382 

This PR adds support to `jlink` so that we no longer require users to download a jre when using vortex. Now a jre will be shipped as part of `zip` artifacts generated. This mostly mimics https://github.com/bitcoin-s/bitcoin-s/pull/4316 . This PR takes advantage of the [sbt native packagers jlink support](https://www.scala-sbt.org/sbt-native-packager/archetypes/jlink_plugin.html)


<img width="1440" alt="Screen Shot 2022-10-13 at 6 30 23 PM" src="https://user-images.githubusercontent.com/3514957/195729504-1e139e55-0788-48e4-95cb-ed97b602ad5d.png">

- [ ] You probably will want to add OS specific builds for your binaries. `jlink`'d binaries are not necessarily cross platform safe. This PR is where we did it on bitcoin-s (see `yml` file changes): https://github.com/bitcoin-s/bitcoin-s/pull/4322
- [x] on mac os the `jre/bin/java` binary will not be executable if artifacts are _not_ built on the user's machine (i.e they are built on CI). We have added extra bash scripts upstream to make it executable. You will want to pull this in on a follow up PR: https://github.com/bitcoin-s/bitcoin-s/pull/4322/files#diff-0a130d65602453d7af80eaf0aa6c0c72c9c7508c7b4db73349f6fb359c1f116d (done in 188dba7094b9d3dfcd8854258a94b77053c1fb9f)
- [x] Don't remove java base images on docker. I spent a lot of time debugging why `jlink`'d jre's weren't working on docker, and turns out they cannot reliably work across all host OS environments: https://github.com/bitcoin-s/bitcoin-s/issues/4383 . As a byproduct you may need to implement the `DISABLE_JLINK` environment variable so that jlink can be disabled which causes the bash startup scripts to fallback to the OS jre rather than the jre we ship: https://github.com/bitcoin-s/bitcoin-s/pull/4426 (done in 188dba7094b9d3dfcd8854258a94b77053c1fb9f and e7f9406 )

