### PR TITLE
Switch to setup-java action as setup-scala is deprecated

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -12,9 +12,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Scala
-        uses: olafurpg/setup-scala@v13
+        uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          distribution: 'adopt'
+          java-version: '18'
+          cache: 'sbt'
       - name: Cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup Scala
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '18'
+          cache: 'sbt'
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Scala
-        uses: olafurpg/setup-scala@v13
+        uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          distribution: 'adopt'
+          java-version: '18'
+          cache: 'sbt'
       - name: Cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/tor_test.yml
+++ b/.github/workflows/tor_test.yml
@@ -14,9 +14,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Scala
-        uses: olafurpg/setup-scala@v13
+        uses: actions/setup-java@v3
         with:
-          java-version: zulu@1.11
+          distribution: 'adopt'
+          java-version: '18'
+          cache: 'sbt'
       - name: Cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Fixes this CI error when publishing docker images: https://github.com/ln-vortex/ln-vortex/actions/runs/3252780117/jobs/5339363576#step:4:59

if are you are curious of the details see: https://github.com/bitcoin-s/bitcoin-s/pull/4718

This PR also moves away from using `setup-scala` github action. This is because it has been deprecated by the action owner with the recommendation to switching to `setup-java`

https://github.com/actions/setup-java#setup-java

https://github.com/bitcoin-s/bitcoin-s/pull/4466