### PR TITLE
Set tor conf file name

### DIFF
--- a/client/src/main/scala/com/lnvortex/client/config/VortexAppConfig.scala
+++ b/client/src/main/scala/com/lnvortex/client/config/VortexAppConfig.scala
@@ -58,7 +58,9 @@ case class VortexAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   override def stop(): Future[Unit] = Future.unit
 
   lazy val torConf: TorAppConfig =
-    TorAppConfig(baseDatadir, None, configOverrides)
+    new TorAppConfig(baseDatadir, None, configOverrides) {
+      override def configFileName: String = CONFIG_FILE_NAME
+    }
 
   lazy val socks5ProxyParams: Option[Socks5ProxyParams] = {
     torConf.socks5ProxyParams

--- a/server/src/main/scala/com/lnvortex/server/config/VortexCoordinatorAppConfig.scala
+++ b/server/src/main/scala/com/lnvortex/server/config/VortexCoordinatorAppConfig.scala
@@ -89,7 +89,9 @@ case class VortexCoordinatorAppConfig(
   }
 
   lazy val torConf: TorAppConfig =
-    TorAppConfig(directory, None, configOverrides)
+    new TorAppConfig(baseDatadir, None, configOverrides) {
+      override def configFileName: String = CONFIG_FILE_NAME
+    }
 
   lazy val kmConf: KeyManagerAppConfig =
     KeyManagerAppConfig(directory, configOverrides)


### PR DESCRIPTION
The tor config was being properly read in because it was trying to find from a `bitcoin-s.conf` file